### PR TITLE
Add more validation rules to Deployment model

### DIFF
--- a/app/models/deployment.rb
+++ b/app/models/deployment.rb
@@ -2,7 +2,7 @@ class Deployment < ApplicationRecord
   validates :name,
     presence: true,
     uniqueness: { case_sensitive: false },
-    format: { with: NAME_FORMAT },
+    format: { with: HOSTNAME_FORMAT },
     length: { minimum: 1, maximum: 255 }
 
   belongs_to :cluster

--- a/app/models/deployment.rb
+++ b/app/models/deployment.rb
@@ -7,6 +7,8 @@ class Deployment < ApplicationRecord
 
   validates :desired_num_replicas,
     numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 99 }
+  validates :min_available_replicas,
+    numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 99 }
 
   belongs_to :cluster
 

--- a/app/models/deployment.rb
+++ b/app/models/deployment.rb
@@ -5,6 +5,9 @@ class Deployment < ApplicationRecord
     format: { with: HOSTNAME_FORMAT },
     length: { minimum: 1, maximum: 255 }
 
+  validates :desired_num_replicas,
+    numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 99 }
+
   belongs_to :cluster
 
   def container_names

--- a/spec/models/deployment_spec.rb
+++ b/spec/models/deployment_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe Deployment, type: :model do
 
     it { should validate_numericality_of(:desired_num_replicas).is_greater_than_or_equal_to(0) }
     it { should validate_numericality_of(:desired_num_replicas).is_less_than_or_equal_to(99) }
+    it { should validate_numericality_of(:min_available_replicas).is_greater_than_or_equal_to(0) }
+    it { should validate_numericality_of(:min_available_replicas).is_less_than_or_equal_to(99) }
   end
 
   describe "methods" do

--- a/spec/models/deployment_spec.rb
+++ b/spec/models/deployment_spec.rb
@@ -5,8 +5,9 @@ RSpec.describe Deployment, type: :model do
     it { should validate_presence_of(:name) }
     it { should validate_length_of(:name).is_at_least(1).is_at_most(255) }
     it { create(:deployment); is_expected.to validate_uniqueness_of(:name).case_insensitive }
-    it { should allow_value('IDENT_NAME').for(:name) }
     it { should allow_value('ident-name').for(:name) }
+    it { should_not allow_value('IDENT_NAME').for(:name) }
+    it { should_not allow_value('ident name').for(:name) }
     it { should_not allow_value(' ident name').for(:name) }
   end
 

--- a/spec/models/deployment_spec.rb
+++ b/spec/models/deployment_spec.rb
@@ -9,6 +9,9 @@ RSpec.describe Deployment, type: :model do
     it { should_not allow_value('IDENT_NAME').for(:name) }
     it { should_not allow_value('ident name').for(:name) }
     it { should_not allow_value(' ident name').for(:name) }
+
+    it { should validate_numericality_of(:desired_num_replicas).is_greater_than_or_equal_to(0) }
+    it { should validate_numericality_of(:desired_num_replicas).is_less_than_or_equal_to(99) }
   end
 
   describe "methods" do


### PR DESCRIPTION
- `name` should be in hostname format because it'll be used as part of containers name.
- `desired_num_replicas`, `min_available_replicas` should be in range of 0-99.