### PR TITLE
Fix Container button href in cluster detail view

### DIFF
--- a/app/views/clusters/show.html.slim
+++ b/app/views/clusters/show.html.slim
@@ -23,7 +23,7 @@ tr.d-flex
       = link_to 'Deployments', deployments_cluster_path(@cluster), class: 'text-light', style: 'text-decoration:none'
   td.col-1.word-wrap
     .btn.btn-success.btn-sm.mr-1
-      = link_to 'Containers', deployments_cluster_path(@cluster), class: 'text-light', style: 'text-decoration:none'
+      = link_to 'Containers', containers_cluster_path(@cluster), class: 'text-light', style: 'text-decoration:none'
 
 #results
   br


### PR DESCRIPTION
The Container button directs to the wrong page.