### PR TITLE
Fix update container API

### DIFF
--- a/app/controllers/api/v2/ext_app/containers_controller.rb
+++ b/app/controllers/api/v2/ext_app/containers_controller.rb
@@ -55,8 +55,9 @@ class ::Api::V2::ExtApp::ContainersController < ::Api::V2::ExtApp::BaseControlle
   def update
     @cluster = ::Cluster.find_by!(name: params[:cluster_name])
     @container = @cluster.containers.exists.find_by(hostname: params[:hostname])
-    @container.update_bootstrappers(params[:bootstrappers])
-    @container.update_source(params[:source])
+    @container.apply_params_with_source(params)
+    @container.save!
+    @container.reload
     render json: ::Api::V2::ExtApp::ContainerSerializer.new(@container).to_h
   end
   

--- a/app/models/container.rb
+++ b/app/models/container.rb
@@ -108,21 +108,6 @@ class Container < ApplicationRecord
     end
   end
 
-  def update_source(new_source)
-    if new_source.nil? || new_source.blank?
-      false
-    else
-      source = Source.find_or_create_by(
-        source_type: new_source[:source_type],
-        mode: new_source[:mode],
-        remote_id: new_source[:remote_id],
-        fingerprint: new_source[:fingerprint],
-        alias: new_source[:alias]
-      )
-      update_column(:source_id, source.id)
-    end
-  end
-
   def update_status(status)
     status = status.downcase.to_sym
     if Container.statuses.key?(status)

--- a/spec/models/container_spec.rb
+++ b/spec/models/container_spec.rb
@@ -185,27 +185,6 @@ RSpec.describe Container, type: :model do
       end
     end
 
-    describe '#update_source' do
-      let(:container) { create(:container) }
-
-      it 'shouldn\'t update source for nil value' do
-        source_update = container.update_source(nil)
-        expect(source_update).to eq(false)
-      end
-
-      it 'shouldn\'t update bootstrapper for empty value' do
-        source_update = container.update_source("")
-        expect(source_update).to eq(false)
-      end
-
-      it 'should update container bootstrapper' do
-        new_source = create(:source)
-        source_update = container.update_source(new_source)
-        expect(source_update).to eq(true)
-        expect(container.source).to eq(new_source)
-      end
-    end
-
     describe '#ready?' do
       before(:each) do
         Container.statuses.each do |_, status|


### PR DESCRIPTION
Fix `update` container API by changing the API to use `apply_params_with_source` instead of making a new function