### PR TITLE
Don't reject missing metrics from previous agent version

### DIFF
--- a/app/controllers/api/v1/node/nodes_controller.rb
+++ b/app/controllers/api/v1/node/nodes_controller.rb
@@ -1,20 +1,20 @@
 class ::Api::V1::Node::NodesController < ::Api::V1::Node::BaseController
   def store_metrics
     current_node.update_attributes(
-      mem_free_mb: params[:memory][:free],
-      mem_used_mb: params[:memory][:used],
-      mem_total_mb: params[:memory][:total],
+      mem_free_mb: params.dig(:memory, :free),
+      mem_used_mb: params.dig(:memory, :used),
+      mem_total_mb: params.dig(:memory, :total),
 
-      load_capacity: params[:load][:capacity],
-      load_avg_1m: params[:load][:load_avg_1m],
-      load_avg_5m: params[:load][:load_avg_5m],
-      load_avg_15m: params[:load][:load_avg_15m],
+      load_capacity: params.dig(:load, :capacity),
+      load_avg_1m: params.dig(:load, :load_avg_1m),
+      load_avg_5m: params.dig(:load, :load_avg_5m),
+      load_avg_15m: params.dig(:load, :load_avg_15m),
 
-      disk_root_used_mb: params[:disk_root][:used],
-      disk_root_total_mb: params[:disk_root][:total],
+      disk_root_used_mb: params.dig(:disk_root, :used),
+      disk_root_total_mb: params.dig(:disk_root, :total),
 
-      disk_zfs_used_mb: params[:disk_zfs][:used],
-      disk_zfs_total_mb: params[:disk_zfs][:total],
+      disk_zfs_used_mb: params.dig(:disk_zfs, :used),
+      disk_zfs_total_mb: params.dig(:disk_zfs, :total),
     )
 
     render json: ::Api::V1::Node::NodeSerializer.new(current_node).to_h

--- a/spec/controllers/api/v1/node/nodes_controller_spec.rb
+++ b/spec/controllers/api/v1/node/nodes_controller_spec.rb
@@ -34,5 +34,18 @@ RSpec.describe ::Api::V1::Node::NodesController do
       post :store_metrics, params: params, as: :json
       expect(response.body).to eq ::Api::V1::Node::NodeSerializer.new(@node.reload).to_h.to_json
     end
+
+    it 'still works even some metrics is missing' do
+      params = {
+        cluster_name: @cluster.name,
+        memory: {
+          used: 10,
+          total: 30
+        },
+      }
+
+      post :store_metrics, params: params, as: :json
+      expect(response.body).to eq ::Api::V1::Node::NodeSerializer.new(@node.reload).to_h.to_json
+    end
   end
 end


### PR DESCRIPTION
This is needed for backward-compatibility.